### PR TITLE
Authentication: clear text, md5 and without password

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ go:
   - 1.10.x
 
 install:
-  - go get -t -v ./... # all deps
   - go get -u github.com/golang/lint/golint
+  - go get -t -v ./...
   - export PATH=$PATH:$HOME/.local/bin
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ go:
   - 1.10.x
 
 install:
+  - go get -t -v ./... # all deps
   - go get -u github.com/golang/lint/golint
-  - go get github.com/lfittl/pg_query_go
   - export PATH=$PATH:$HOME/.local/bin
 
 script:

--- a/auth.go
+++ b/auth.go
@@ -141,6 +141,11 @@ func (a *authenticationMD5) authenticate() (msg, error) {
 	return authOKMsg(), nil
 }
 
+// authOKMsg returns a message that indicates that the client is now authenticated.
+func authOKMsg() msg {
+	return []byte{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+}
+
 // getRandomSalt returns a cryptographically secure random slice of 4 bytes.
 func getRandomSalt() []byte {
 	salt := make([]byte, 4)

--- a/auth.go
+++ b/auth.go
@@ -1,11 +1,167 @@
 package pgsrv
 
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/rand"
+	"fmt"
+)
+
+// authenticator interface defines objects able to perform user authentication
+// that happens at the very beginning of every session.
 type authenticator interface {
-	authenticate() msg
+	authenticate() (msg, error)
 }
 
-type noPassword struct{}
+// authenticationNoPassword responds with auth OK immediately.
+type authenticationNoPassword struct{}
 
-func (*noPassword) authenticate() msg {
-	return msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+func (*authenticationNoPassword) authenticate() (msg, error) {
+	return msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}, nil
+}
+
+// messageReadWriter describes objects that handle client-server communication.
+// Objects implementing this interface are used to send password requests to users,
+// and receive their responses.
+type messageReadWriter interface {
+	Write(m msg) error
+	Read() (msg, error)
+}
+
+// passwordProvider describes objects that are able to provide a password given a user name.
+type passwordProvider interface {
+	getPassword(user string) ([]byte, error)
+}
+
+// constantPasswordProvider is a password provider that always returns the same password,
+// which it is given during the initialization.
+type constantPasswordProvider struct {
+	password []byte
+}
+
+func (cpp *constantPasswordProvider) getPassword(user string) ([]byte, error) {
+	return cpp.password, nil
+}
+
+// authenticationClearText is an authenticator that requests and accepts a clear text password
+// from the client. It is not recommended to use it for security reasons.
+//
+// It requires a messageReadWriter implementation to communicate with the client,
+// passwordProvider implementation to verify that the provided password is correct,
+// and a map of arguments that were sent at the beginning of the session (user, database, etc)
+type authenticationClearText struct {
+	rw   messageReadWriter
+	args map[string]interface{}
+	pp   passwordProvider
+}
+
+func (a *authenticationClearText) authenticate() (msg, error) {
+	// AuthenticationClearText
+	passwordRequest := msg{
+		'R',
+		0, 0, 0, 8,
+		0, 0, 0, 3,
+	}
+
+	err := a.rw.Write(passwordRequest)
+	if err != nil {
+		return msg{}, err
+	}
+
+	m, err := a.rw.Read()
+	if err != nil {
+		return msg{}, err
+	}
+
+	if m.Type() != 'p' {
+		return msg{},
+			fmt.Errorf("expected password response, got message type %c", m.Type())
+	}
+
+	user := a.args["user"].(string)
+	expectedPassword, err := a.pp.getPassword(user)
+	actualPassword := extractPassword(m)
+
+	if !bytes.Equal(expectedPassword, actualPassword) {
+		return msg{},
+			fmt.Errorf("Password does not match for user \"%s\"", user)
+	}
+
+	return authOKMsg(), nil
+}
+
+// authenticationMD5 is an authenticator that requests and accepts an MD5 hashed password
+// from the client.
+//
+// It requires a messageReadWriter implementation to communicate with the client,
+// passwordProvider implementation to verify that the provided password is correct,
+// and a map of arguments that were sent at the beginning of the session (user, database, etc)
+type authenticationMD5 struct {
+	rw   messageReadWriter
+	args map[string]interface{}
+	pp   passwordProvider
+}
+
+func (a *authenticationMD5) authenticate() (msg, error) {
+	// AuthenticationMD5Password
+	passwordRequest := msg{
+		'R',
+		0, 0, 0, 12,
+		0, 0, 0, 5,
+	}
+	salt := getRandomSalt()
+	passwordRequest = append(passwordRequest, salt...)
+
+	err := a.rw.Write(passwordRequest)
+	if err != nil {
+		return msg{}, err
+	}
+
+	m, err := a.rw.Read()
+	if err != nil {
+		return msg{}, err
+	}
+
+	if m.Type() != 'p' {
+		return msg{},
+			fmt.Errorf("expected password response, got message type %c", m.Type())
+	}
+
+	user := a.args["user"].(string)
+	expectedPassword, err := a.pp.getPassword(user)
+	expectedHash := hashUserPassword(user, expectedPassword, salt)
+
+	actualHash := extractPassword(m)
+
+	if !bytes.Equal(expectedHash, actualHash) {
+		return msg{},
+			fmt.Errorf("Password does not match for user \"%s\"", user)
+	}
+
+	return authOKMsg(), nil
+}
+
+// getRandomSalt returns a cryptographically secure random slice of 4 bytes.
+func getRandomSalt() []byte {
+	salt := make([]byte, 4)
+	rand.Read(salt)
+	return salt
+}
+
+// extractPassword extracts the password from a provided 'p' message.
+// It assumes that the message is valid.
+func extractPassword(m msg) []byte {
+	// password starts after the size (4 bytes) and lasts until null-terminator
+	return m[5 : len(m)-1]
+}
+
+// hashUserPassword hashes the provided username and password with the provided salt
+// using the same MD5 hashing technique as postgresql MD5 authentication
+func hashUserPassword(user string, password, salt []byte) []byte {
+	// concat('md5', md5(concat(md5(concat(password, username)), random-salt)))
+	pu := append(password, []byte(user)...)
+	puHash := fmt.Sprintf("%x", md5.Sum(pu))
+	puHashSalted := append([]byte(puHash), salt...)
+	finalHash := fmt.Sprintf("md5%x", md5.Sum(puHashSalted))
+	return []byte(finalHash)
 }

--- a/auth.go
+++ b/auth.go
@@ -17,7 +17,7 @@ type authenticator interface {
 type authenticationNoPassword struct{}
 
 func (*authenticationNoPassword) authenticate() (msg, error) {
-	return msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}, nil
+	return authOKMsg(), nil
 }
 
 // messageReadWriter describes objects that handle client-server communication.

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,11 @@
+package pgsrv
+
+type authenticator interface {
+	authenticate() msg
+}
+
+type noPassword struct{}
+
+func (*noPassword) authenticate() msg {
+	return msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,13 @@
+package pgsrv
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNoPassword_authenticate(t *testing.T) {
+	np := &noPassword{}
+	actualResult := np.authenticate()
+	expectedResult := msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+	require.Equal(t, actualResult, expectedResult)
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -7,6 +7,13 @@ import (
 
 var authOKMessage = msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}
 
+func TestAuthOKMsg(t *testing.T) {
+	actualResult := authOKMsg()
+	expectedResult := authOKMessage
+
+	require.Equal(t, expectedResult, actualResult)
+}
+
 func TestNoPassword_authenticate(t *testing.T) {
 	np := &authenticationNoPassword{}
 	actualResult, err := np.authenticate()

--- a/auth_test.go
+++ b/auth_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 )
 
+var authOKMessage = msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+
 func TestNoPassword_authenticate(t *testing.T) {
 	np := &authenticationNoPassword{}
 	actualResult, err := np.authenticate()
-	expectedResult := msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+	expectedResult := authOKMessage
 
 	require.NoError(t, err)
 	require.Equal(t, actualResult, expectedResult)
@@ -29,7 +31,7 @@ func TestAuthenticationClearText_authenticate(t *testing.T) {
 	a := &authenticationClearText{rw, args, pp}
 
 	t.Run("valid password", func(t *testing.T) {
-		expectedResult := authOKMsg()
+		expectedResult := authOKMessage
 		actualResult, err := a.authenticate()
 
 		require.NoError(t, err)
@@ -69,7 +71,7 @@ func TestAuthenticationMD5_authenticate(t *testing.T) {
 	a := &authenticationMD5{rw, args, pp}
 
 	t.Run("valid password", func(t *testing.T) {
-		expectedResult := authOKMsg()
+		expectedResult := authOKMessage
 		actualResult, err := a.authenticate()
 
 		require.NoError(t, err)

--- a/auth_test.go
+++ b/auth_test.go
@@ -6,8 +6,181 @@ import (
 )
 
 func TestNoPassword_authenticate(t *testing.T) {
-	np := &noPassword{}
-	actualResult := np.authenticate()
+	np := &authenticationNoPassword{}
+	actualResult, err := np.authenticate()
 	expectedResult := msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+
+	require.NoError(t, err)
 	require.Equal(t, actualResult, expectedResult)
+}
+
+func TestAuthenticationClearText_authenticate(t *testing.T) {
+	passwordMessage := msg{
+		'p',
+		0, 0, 0, 8,
+		109, 101, 104, 0, // 'meh'
+	}
+	rw := &mockMessageReadWriter{output: []msg{passwordMessage}}
+	args := map[string]interface{}{
+		"user": "this-is-user",
+	}
+	pp := &constantPasswordProvider{password: []byte("meh")}
+
+	a := &authenticationClearText{rw, args, pp}
+
+	t.Run("valid password", func(t *testing.T) {
+		expectedResult := authOKMsg()
+		actualResult, err := a.authenticate()
+
+		require.NoError(t, err)
+		require.Equal(t, expectedResult, actualResult)
+	})
+
+	t.Run("invalid password", func(t *testing.T) {
+		pp.password = []byte("shtoot")
+		_, err := a.authenticate()
+
+		require.EqualError(t, err,
+			"Password does not match for user \"this-is-user\"")
+	})
+
+	t.Run("invalid message type", func(t *testing.T) {
+		a.rw = &mockMessageReadWriter{output: []msg{
+			{'q', 0, 0, 0, 5, 1},
+		}}
+		_, err := a.authenticate()
+
+		require.EqualError(t, err,
+			"expected password response, got message type q")
+	})
+}
+
+func TestAuthenticationMD5_authenticate(t *testing.T) {
+	rw := &mockMD5MessageReadWriter{
+		user: "postgres",
+		pass: []byte("test"),
+		salt: []byte{},
+	}
+	args := map[string]interface{}{
+		"user": "postgres",
+	}
+	pp := &constantPasswordProvider{password: []byte("test")}
+
+	a := &authenticationMD5{rw, args, pp}
+
+	t.Run("valid password", func(t *testing.T) {
+		expectedResult := authOKMsg()
+		actualResult, err := a.authenticate()
+
+		require.NoError(t, err)
+		require.Equal(t, expectedResult, actualResult)
+	})
+
+	t.Run("invalid password", func(t *testing.T) {
+		pp.password = []byte("shtoot")
+		_, err := a.authenticate()
+
+		require.EqualError(t, err,
+			"Password does not match for user \"postgres\"")
+	})
+
+	t.Run("invalid message type", func(t *testing.T) {
+		a.rw = &mockMessageReadWriter{output: []msg{
+			{'q', 0, 0, 0, 5, 1},
+		}}
+		_, err := a.authenticate()
+
+		require.EqualError(t, err,
+			"expected password response, got message type q")
+	})
+}
+
+func TestHashUserPassword(t *testing.T) {
+	user := "postgres"
+	pass := []byte("test")
+	salt := []byte{196, 53, 49, 235}
+
+	// actual hash received from psql using the above variables
+	expectedHash := []byte{
+		109, 100, 53, 97, 97, 51, 102, 56, 98, 56,
+		55, 97, 57, 51, 52, 97, 52, 53, 48, 52,
+		52, 101, 49, 102, 98, 50, 100, 57, 48, 55,
+		48, 99, 98, 56, 48,
+	}
+
+	actualHash := hashUserPassword(user, pass, salt)
+	require.Equal(t, expectedHash, actualHash)
+}
+
+func TestGetRandomSalt(t *testing.T) {
+	var lastSalt []byte
+	for i := 0; i < 100; i++ {
+		salt := getRandomSalt()
+		require.Equal(t, len(salt), 4)
+		require.NotEqual(t, lastSalt, salt)
+		lastSalt = salt
+	}
+}
+
+func TestExtractPassword(t *testing.T) {
+	t.Run("regular password", func(t *testing.T) {
+		passwordMessage := msg{
+			'p',
+			0, 0, 0, 9,
+			42, 42, 42, 42,
+			0,
+		}
+
+		expectedResult := []byte{42, 42, 42, 42}
+		actualResult := extractPassword(passwordMessage)
+		require.Equal(t, expectedResult, actualResult)
+	})
+
+	t.Run("empty password", func(t *testing.T) {
+		passwordMessage := msg{
+			'p',
+			0, 0, 0, 5,
+			0,
+		}
+
+		expectedResult := []byte{}
+		actualResult := extractPassword(passwordMessage)
+		require.Equal(t, expectedResult, actualResult)
+	})
+}
+
+// mockMessageReadWriter implements messageReadWriter and outputs the provided output
+// message by message, looped.
+type mockMessageReadWriter struct {
+	output        []msg
+	currentOutput int
+}
+
+func (rw *mockMessageReadWriter) Read() (msg, error) {
+	return rw.output[rw.currentOutput%len(rw.output)], nil
+}
+
+func (rw *mockMessageReadWriter) Write(m msg) error { return nil }
+
+// mockMD5MessageReadWriter implements messageReadWriter and outputs password
+// hashed with the salt received in Write() method
+type mockMD5MessageReadWriter struct {
+	user string
+	pass []byte
+	salt []byte
+}
+
+func (rw *mockMD5MessageReadWriter) Read() (msg, error) {
+	message := msg{
+		'p',
+		0, 0, 0, 25,
+	}
+	message = append(message, hashUserPassword(rw.user, rw.pass, rw.salt)...)
+	message = append(message, 0)
+	return message, nil
+}
+
+func (rw *mockMD5MessageReadWriter) Write(m msg) error {
+	rw.salt = m[9:len(m)]
+	return nil
 }

--- a/errors.go
+++ b/errors.go
@@ -26,6 +26,7 @@ import (
 type Err error
 
 type err struct {
+	S string // Severity
 	C string // Code
 	M string // Message
 	D string // Detail
@@ -33,11 +34,23 @@ type err struct {
 	P int    // Position
 }
 
-func (e *err) Code() string   { return e.C }
-func (e *err) Error() string  { return e.M }
-func (e *err) Detail() string { return e.D }
-func (e *err) Hint() string   { return e.H }
-func (e *err) Position() int  { return e.P }
+func (e *err) Severity() string { return e.S }
+func (e *err) Code() string     { return e.C }
+func (e *err) Error() string    { return e.M }
+func (e *err) Detail() string   { return e.D }
+func (e *err) Hint() string     { return e.H }
+func (e *err) Position() int    { return e.P }
+
+// WithSeverity decorates an error object to also include an optional severity
+func WithSeverity(err error, severity string) Err {
+	if err == nil {
+		return nil
+	}
+
+	e := fromErr(err)
+	e.S = severity
+	return e
+}
 
 // WithDetail decorates an error object to also include  an optional secondary
 // error message carrying more detail about the problem. Might run to multiple

--- a/msg_query.go
+++ b/msg_query.go
@@ -106,6 +106,14 @@ func errMsg(err error) msg {
 		"M": err.Error(),
 	}
 
+	// severity
+	errSeverity, ok := err.(interface {
+		Severity() string
+	})
+	if ok && errSeverity.Severity() != "" {
+		fields["S"] = errSeverity.Severity()
+	}
+
 	// error code
 	errCode, ok := err.(interface {
 		Code() string

--- a/msg_startup.go
+++ b/msg_startup.go
@@ -82,12 +82,6 @@ func tlsResponseMsg(supported bool) msg {
 	return msg([]byte{b})
 }
 
-// NewAuthOK creates a new message indicating that the authentication was
-// successful
-func authOKMsg() msg {
-	return []byte{'R', 0, 0, 0, 8, 0, 0, 0, 0}
-}
-
 // KeyDataMsg creates a new message providing the client with a process ID and
 // secret key that it can later use to cancel running queries
 func keyDataMsg(pid int32, secret int32) msg {

--- a/sess.go
+++ b/sess.go
@@ -92,6 +92,8 @@ func (s *session) Serve() error {
 		return err
 	}
 
+	s.initialized = true
+
 	// handle authentication.
 	err = s.Write(authOKMsg())
 	if err != nil {
@@ -118,7 +120,6 @@ func (s *session) Serve() error {
 	}
 
 	// query-cycle
-	s.initialized = true
 	for {
 		// notify the client that we're ready for more messages.
 		err = s.Write(readyMsg())

--- a/sess.go
+++ b/sess.go
@@ -95,7 +95,13 @@ func (s *session) Serve() error {
 	s.initialized = true
 
 	// handle authentication.
-	err = s.Write(authOKMsg())
+	a := &authenticationNoPassword{}
+	authResponse, err := a.authenticate()
+	if err != nil {
+		return s.Write(errMsg(WithSeverity(err, "FATAL")))
+	}
+
+	err = s.Write(authResponse)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
[Task](https://app.asana.com/0/573768021211412/768621478822192/f)

This PR adds `authenticator` interface and its 3 implementations:
- without password (to keep things as they are now)
- clear text password
- md5 hashed password

Last two implementations use dependency injection and delegate tasks like "get password for user" to provided objects. This also helps in testing (`auth.go` is almost completely covered with unit tests).

This PR also modifies `err` type: it adds a new field for severity (auth errors are `FATAL`; `ERROR` is not enough for them)

Currently, `sess.go` uses `authenticationNoPassword`. An example of md5 looks like the following:

```go
// password provider - implement when available
pp := &constantPasswordProvider{password: []byte("password")}

// authenticator that accepts current session as rw (readWriter),
// session args and password provider
a := &authenticationMD5{rw: s, args: s.Args, pp: pp}

authResponse, err := a.authenticate()
if err != nil {
	return s.Write(errMsg(WithSeverity(err, "FATAL")))
}
```