### PR TITLE
Authentication: clear text, md5 and without password 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ go:
   - 1.10.x
 
 install:
-  - go get -t -v ./... # all deps
   - go get -u github.com/golang/lint/golint
+  - go get -t -v ./...
   - export PATH=$PATH:$HOME/.local/bin
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ go:
   - 1.10.x
 
 install:
+  - go get -t -v ./... # all deps
   - go get -u github.com/golang/lint/golint
-  - go get github.com/lfittl/pg_query_go
   - export PATH=$PATH:$HOME/.local/bin
 
 script:

--- a/auth.go
+++ b/auth.go
@@ -141,6 +141,11 @@ func (a *authenticationMD5) authenticate() (msg, error) {
 	return authOKMsg(), nil
 }
 
+// authOKMsg returns a message that indicates that the client is now authenticated.
+func authOKMsg() msg {
+	return []byte{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+}
+
 // getRandomSalt returns a cryptographically secure random slice of 4 bytes.
 func getRandomSalt() []byte {
 	salt := make([]byte, 4)

--- a/auth.go
+++ b/auth.go
@@ -1,11 +1,167 @@
 package pgsrv
 
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/rand"
+	"fmt"
+)
+
+// authenticator interface defines objects able to perform user authentication
+// that happens at the very beginning of every session.
 type authenticator interface {
-	authenticate() msg
+	authenticate() (msg, error)
 }
 
-type noPassword struct{}
+// authenticationNoPassword responds with auth OK immediately.
+type authenticationNoPassword struct{}
 
-func (*noPassword) authenticate() msg {
-	return msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+func (*authenticationNoPassword) authenticate() (msg, error) {
+	return msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}, nil
+}
+
+// messageReadWriter describes objects that handle client-server communication.
+// Objects implementing this interface are used to send password requests to users,
+// and receive their responses.
+type messageReadWriter interface {
+	Write(m msg) error
+	Read() (msg, error)
+}
+
+// passwordProvider describes objects that are able to provide a password given a user name.
+type passwordProvider interface {
+	getPassword(user string) ([]byte, error)
+}
+
+// constantPasswordProvider is a password provider that always returns the same password,
+// which it is given during the initialization.
+type constantPasswordProvider struct {
+	password []byte
+}
+
+func (cpp *constantPasswordProvider) getPassword(user string) ([]byte, error) {
+	return cpp.password, nil
+}
+
+// authenticationClearText is an authenticator that requests and accepts a clear text password
+// from the client. It is not recommended to use it for security reasons.
+//
+// It requires a messageReadWriter implementation to communicate with the client,
+// passwordProvider implementation to verify that the provided password is correct,
+// and a map of arguments that were sent at the beginning of the session (user, database, etc)
+type authenticationClearText struct {
+	rw   messageReadWriter
+	args map[string]interface{}
+	pp   passwordProvider
+}
+
+func (a *authenticationClearText) authenticate() (msg, error) {
+	// AuthenticationClearText
+	passwordRequest := msg{
+		'R',
+		0, 0, 0, 8,
+		0, 0, 0, 3,
+	}
+
+	err := a.rw.Write(passwordRequest)
+	if err != nil {
+		return msg{}, err
+	}
+
+	m, err := a.rw.Read()
+	if err != nil {
+		return msg{}, err
+	}
+
+	if m.Type() != 'p' {
+		return msg{},
+			fmt.Errorf("expected password response, got message type %c", m.Type())
+	}
+
+	user := a.args["user"].(string)
+	expectedPassword, err := a.pp.getPassword(user)
+	actualPassword := extractPassword(m)
+
+	if !bytes.Equal(expectedPassword, actualPassword) {
+		return msg{},
+			fmt.Errorf("Password does not match for user \"%s\"", user)
+	}
+
+	return authOKMsg(), nil
+}
+
+// authenticationMD5 is an authenticator that requests and accepts an MD5 hashed password
+// from the client.
+//
+// It requires a messageReadWriter implementation to communicate with the client,
+// passwordProvider implementation to verify that the provided password is correct,
+// and a map of arguments that were sent at the beginning of the session (user, database, etc)
+type authenticationMD5 struct {
+	rw   messageReadWriter
+	args map[string]interface{}
+	pp   passwordProvider
+}
+
+func (a *authenticationMD5) authenticate() (msg, error) {
+	// AuthenticationMD5Password
+	passwordRequest := msg{
+		'R',
+		0, 0, 0, 12,
+		0, 0, 0, 5,
+	}
+	salt := getRandomSalt()
+	passwordRequest = append(passwordRequest, salt...)
+
+	err := a.rw.Write(passwordRequest)
+	if err != nil {
+		return msg{}, err
+	}
+
+	m, err := a.rw.Read()
+	if err != nil {
+		return msg{}, err
+	}
+
+	if m.Type() != 'p' {
+		return msg{},
+			fmt.Errorf("expected password response, got message type %c", m.Type())
+	}
+
+	user := a.args["user"].(string)
+	expectedPassword, err := a.pp.getPassword(user)
+	expectedHash := hashUserPassword(user, expectedPassword, salt)
+
+	actualHash := extractPassword(m)
+
+	if !bytes.Equal(expectedHash, actualHash) {
+		return msg{},
+			fmt.Errorf("Password does not match for user \"%s\"", user)
+	}
+
+	return authOKMsg(), nil
+}
+
+// getRandomSalt returns a cryptographically secure random slice of 4 bytes.
+func getRandomSalt() []byte {
+	salt := make([]byte, 4)
+	rand.Read(salt)
+	return salt
+}
+
+// extractPassword extracts the password from a provided 'p' message.
+// It assumes that the message is valid.
+func extractPassword(m msg) []byte {
+	// password starts after the size (4 bytes) and lasts until null-terminator
+	return m[5 : len(m)-1]
+}
+
+// hashUserPassword hashes the provided username and password with the provided salt
+// using the same MD5 hashing technique as postgresql MD5 authentication
+func hashUserPassword(user string, password, salt []byte) []byte {
+	// concat('md5', md5(concat(md5(concat(password, username)), random-salt)))
+	pu := append(password, []byte(user)...)
+	puHash := fmt.Sprintf("%x", md5.Sum(pu))
+	puHashSalted := append([]byte(puHash), salt...)
+	finalHash := fmt.Sprintf("md5%x", md5.Sum(puHashSalted))
+	return []byte(finalHash)
 }

--- a/auth.go
+++ b/auth.go
@@ -93,8 +93,9 @@ func (a *clearTextAuthenticator) authenticate(rw msgReadWriter, args map[string]
 
 	if m.Type() != 'p' {
 		err = fmt.Errorf(errExpectedPassword, m.Type())
-		m := errMsg(WithSeverity(fromErr(err), fatalSeverity))
-		return rw.Write(m)
+		err = WithSeverity(fromErr(err), fatalSeverity)
+		rw.Write(errMsg(err))
+		return err
 	}
 
 	user := args["user"].(string)
@@ -103,8 +104,9 @@ func (a *clearTextAuthenticator) authenticate(rw msgReadWriter, args map[string]
 
 	if !bytes.Equal(expectedPassword, actualPassword) {
 		err = fmt.Errorf(errWrongPassword, user)
-		m := errMsg(WithSeverity(fromErr(err), fatalSeverity))
-		return rw.Write(m)
+		err = WithSeverity(fromErr(err), fatalSeverity)
+		rw.Write(errMsg(err))
+		return err
 	}
 
 	return rw.Write(authOKMsg())
@@ -139,8 +141,9 @@ func (a *md5Authenticator) authenticate(rw msgReadWriter, args map[string]interf
 
 	if m.Type() != 'p' {
 		err = fmt.Errorf(errExpectedPassword, m.Type())
-		m := errMsg(WithSeverity(fromErr(err), fatalSeverity))
-		return rw.Write(m)
+		err = WithSeverity(fromErr(err), fatalSeverity)
+		rw.Write(errMsg(err))
+		return err
 	}
 
 	user := args["user"].(string)
@@ -151,8 +154,9 @@ func (a *md5Authenticator) authenticate(rw msgReadWriter, args map[string]interf
 
 	if !bytes.Equal(expectedHash, actualHash) {
 		err = fmt.Errorf(errWrongPassword, user)
-		m := errMsg(WithSeverity(fromErr(err), fatalSeverity))
-		return rw.Write(m)
+		err = WithSeverity(fromErr(err), fatalSeverity)
+		rw.Write(errMsg(err))
+		return err
 	}
 
 	return rw.Write(authOKMsg())

--- a/auth.go
+++ b/auth.go
@@ -96,7 +96,7 @@ func (a *clearTextAuthenticator) authenticate(rw msgReadWriter, args map[string]
 
 	if m.Type() != 'p' {
 		err = fmt.Errorf(errExpectedPassword, m.Type())
-		m := errMsg(WithSeverity(fromErr(err), FATAL))
+		m := errMsg(WithSeverity(fromErr(err), fatalSeverity))
 		return false, rw.Write(m)
 	}
 
@@ -106,7 +106,7 @@ func (a *clearTextAuthenticator) authenticate(rw msgReadWriter, args map[string]
 
 	if !bytes.Equal(expectedPassword, actualPassword) {
 		err = fmt.Errorf(errWrongPassword, user)
-		m := errMsg(WithSeverity(fromErr(err), FATAL))
+		m := errMsg(WithSeverity(fromErr(err), fatalSeverity))
 		return false, rw.Write(m)
 	}
 
@@ -142,7 +142,7 @@ func (a *md5Authenticator) authenticate(rw msgReadWriter, args map[string]interf
 
 	if m.Type() != 'p' {
 		err = fmt.Errorf(errExpectedPassword, m.Type())
-		m := errMsg(WithSeverity(fromErr(err), FATAL))
+		m := errMsg(WithSeverity(fromErr(err), fatalSeverity))
 		return false, rw.Write(m)
 	}
 
@@ -154,7 +154,7 @@ func (a *md5Authenticator) authenticate(rw msgReadWriter, args map[string]interf
 
 	if !bytes.Equal(expectedHash, actualHash) {
 		err = fmt.Errorf(errWrongPassword, user)
-		m := errMsg(WithSeverity(fromErr(err), FATAL))
+		m := errMsg(WithSeverity(fromErr(err), fatalSeverity))
 		return false, rw.Write(m)
 	}
 

--- a/auth.go
+++ b/auth.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 )
 
+const expectedPasswordMessage = "expected password response, got message type %c"
+const passwordDidNotMatch = "Password does not match for user \"%s\""
+
 // authenticator interface defines objects able to perform user authentication
 // that happens at the very beginning of every session.
 type authenticator interface {
@@ -92,7 +95,7 @@ func (a *clearTextAuthenticator) authenticate(rw msgReadWriter, args map[string]
 	}
 
 	if m.Type() != 'p' {
-		err = fmt.Errorf("expected password response, got message type %c", m.Type())
+		err = fmt.Errorf(expectedPasswordMessage, m.Type())
 		m := errMsg(WithSeverity(fromErr(err), FATAL))
 		return false, rw.Write(m)
 	}
@@ -102,7 +105,7 @@ func (a *clearTextAuthenticator) authenticate(rw msgReadWriter, args map[string]
 	actualPassword := extractPassword(m)
 
 	if !bytes.Equal(expectedPassword, actualPassword) {
-		err = fmt.Errorf("Password does not match for user \"%s\"", user)
+		err = fmt.Errorf(passwordDidNotMatch, user)
 		m := errMsg(WithSeverity(fromErr(err), FATAL))
 		return false, rw.Write(m)
 	}
@@ -138,7 +141,7 @@ func (a *md5Authenticator) authenticate(rw msgReadWriter, args map[string]interf
 	}
 
 	if m.Type() != 'p' {
-		err = fmt.Errorf("expected password response, got message type %c", m.Type())
+		err = fmt.Errorf(expectedPasswordMessage, m.Type())
 		m := errMsg(WithSeverity(fromErr(err), FATAL))
 		return false, rw.Write(m)
 	}
@@ -150,7 +153,7 @@ func (a *md5Authenticator) authenticate(rw msgReadWriter, args map[string]interf
 	actualHash := extractPassword(m)
 
 	if !bytes.Equal(expectedHash, actualHash) {
-		err = fmt.Errorf("Password does not match for user \"%s\"", user)
+		err = fmt.Errorf(passwordDidNotMatch, user)
 		m := errMsg(WithSeverity(fromErr(err), FATAL))
 		return false, rw.Write(m)
 	}

--- a/auth.go
+++ b/auth.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 )
 
-const expectedPasswordMessage = "expected password response, got message type %c"
-const passwordDidNotMatch = "Password does not match for user \"%s\""
+const errExpectedPassword = "expected password response, got message type %c"
+const errWrongPassword = "Password does not match for user \"%s\""
 
 // authenticator interface defines objects able to perform user authentication
 // that happens at the very beginning of every session.
@@ -95,7 +95,7 @@ func (a *clearTextAuthenticator) authenticate(rw msgReadWriter, args map[string]
 	}
 
 	if m.Type() != 'p' {
-		err = fmt.Errorf(expectedPasswordMessage, m.Type())
+		err = fmt.Errorf(errExpectedPassword, m.Type())
 		m := errMsg(WithSeverity(fromErr(err), FATAL))
 		return false, rw.Write(m)
 	}
@@ -105,7 +105,7 @@ func (a *clearTextAuthenticator) authenticate(rw msgReadWriter, args map[string]
 	actualPassword := extractPassword(m)
 
 	if !bytes.Equal(expectedPassword, actualPassword) {
-		err = fmt.Errorf(passwordDidNotMatch, user)
+		err = fmt.Errorf(errWrongPassword, user)
 		m := errMsg(WithSeverity(fromErr(err), FATAL))
 		return false, rw.Write(m)
 	}
@@ -141,7 +141,7 @@ func (a *md5Authenticator) authenticate(rw msgReadWriter, args map[string]interf
 	}
 
 	if m.Type() != 'p' {
-		err = fmt.Errorf(expectedPasswordMessage, m.Type())
+		err = fmt.Errorf(errExpectedPassword, m.Type())
 		m := errMsg(WithSeverity(fromErr(err), FATAL))
 		return false, rw.Write(m)
 	}
@@ -153,7 +153,7 @@ func (a *md5Authenticator) authenticate(rw msgReadWriter, args map[string]interf
 	actualHash := extractPassword(m)
 
 	if !bytes.Equal(expectedHash, actualHash) {
-		err = fmt.Errorf(passwordDidNotMatch, user)
+		err = fmt.Errorf(errWrongPassword, user)
 		m := errMsg(WithSeverity(fromErr(err), FATAL))
 		return false, rw.Write(m)
 	}

--- a/auth.go
+++ b/auth.go
@@ -17,7 +17,7 @@ type authenticator interface {
 type authenticationNoPassword struct{}
 
 func (*authenticationNoPassword) authenticate() (msg, error) {
-	return msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}, nil
+	return authOKMsg(), nil
 }
 
 // messageReadWriter describes objects that handle client-server communication.

--- a/auth.go
+++ b/auth.go
@@ -71,8 +71,8 @@ func (a *clearTextAuthenticator) authenticate() (msg, error) {
 	// AuthenticationClearText
 	passwordRequest := msg{
 		'R',
-		0, 0, 0, 8,
-		0, 0, 0, 3,
+		0, 0, 0, 8, // length
+		0, 0, 0, 3, // clear text auth type
 	}
 
 	err := a.rw.Write(passwordRequest)
@@ -117,8 +117,8 @@ func (a *md5Authenticator) authenticate() (msg, error) {
 	// AuthenticationMD5Password
 	passwordRequest := msg{
 		'R',
-		0, 0, 0, 12,
-		0, 0, 0, 5,
+		0, 0, 0, 12, // length
+		0, 0, 0, 5, // md5 auth type
 	}
 	salt := getRandomSalt()
 	passwordRequest = append(passwordRequest, salt...)

--- a/auth.go
+++ b/auth.go
@@ -13,10 +13,10 @@ type authenticator interface {
 	authenticate() (msg, error)
 }
 
-// authenticationNoPassword responds with auth OK immediately.
-type authenticationNoPassword struct{}
+// noPasswordAuthenticator responds with auth OK immediately.
+type noPasswordAuthenticator struct{}
 
-func (*authenticationNoPassword) authenticate() (msg, error) {
+func (*noPasswordAuthenticator) authenticate() (msg, error) {
 	return authOKMsg(), nil
 }
 
@@ -55,19 +55,19 @@ func (cpp *md5ConstantPasswordProvider) getPassword(user string) ([]byte, error)
 	return puHash[:], nil
 }
 
-// authenticationClearText is an authenticator that requests and accepts a clear text password
-// from the client. It is not recommended to use it for security reasons.
+// clearTextAuthenticator requests and accepts a clear text password.
+// It is not recommended to use it for security reasons.
 //
 // It requires a messageReadWriter implementation to communicate with the client,
 // passwordProvider implementation to verify that the provided password is correct,
 // and a map of arguments that were sent at the beginning of the session (user, database, etc)
-type authenticationClearText struct {
+type clearTextAuthenticator struct {
 	rw   messageReadWriter
 	args map[string]interface{}
 	pp   passwordProvider
 }
 
-func (a *authenticationClearText) authenticate() (msg, error) {
+func (a *clearTextAuthenticator) authenticate() (msg, error) {
 	// AuthenticationClearText
 	passwordRequest := msg{
 		'R',
@@ -102,19 +102,18 @@ func (a *authenticationClearText) authenticate() (msg, error) {
 	return authOKMsg(), nil
 }
 
-// authenticationMD5 is an authenticator that requests and accepts an MD5 hashed password
-// from the client.
+// md5Authenticator requests and accepts an MD5 hashed password from the client.
 //
 // It requires a messageReadWriter implementation to communicate with the client,
 // passwordProvider implementation to verify that the provided password is correct,
 // and a map of arguments that were sent at the beginning of the session (user, database, etc)
-type authenticationMD5 struct {
+type md5Authenticator struct {
 	rw   messageReadWriter
 	args map[string]interface{}
 	pp   passwordProvider
 }
 
-func (a *authenticationMD5) authenticate() (msg, error) {
+func (a *md5Authenticator) authenticate() (msg, error) {
 	// AuthenticationMD5Password
 	passwordRequest := msg{
 		'R',

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,11 @@
+package pgsrv
+
+type authenticator interface {
+	authenticate() msg
+}
+
+type noPassword struct{}
+
+func (*noPassword) authenticate() msg {
+	return msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -26,9 +26,8 @@ func TestNoPassword_authenticate(t *testing.T) {
 	}
 
 	np := &noPasswordAuthenticator{}
-	ok, err := np.authenticate(rw, args)
+	err := np.authenticate(rw, args)
 
-	require.True(t, ok)
 	require.NoError(t, err)
 	require.Equal(t, []msg{authOKMessage}, rw.messages)
 }
@@ -54,9 +53,8 @@ func TestAuthenticationClearText_authenticate(t *testing.T) {
 
 	t.Run("valid password", func(t *testing.T) {
 		defer rw.Reset()
-		ok, err := a.authenticate(rw, args)
+		err := a.authenticate(rw, args)
 
-		require.True(t, ok)
 		require.NoError(t, err)
 		expectedMessages := []msg{
 			passwordRequest,
@@ -68,9 +66,8 @@ func TestAuthenticationClearText_authenticate(t *testing.T) {
 	t.Run("invalid password", func(t *testing.T) {
 		defer rw.Reset()
 		pp.password = []byte("shtoot")
-		ok, err := a.authenticate(rw, args)
+		err := a.authenticate(rw, args)
 
-		require.False(t, ok)
 		require.Equal(t, passwordRequest, rw.messages[0])
 		require.True(t, bytes.Contains(rw.messages[1], fatalMarker))
 		require.NoError(t, err)
@@ -81,9 +78,8 @@ func TestAuthenticationClearText_authenticate(t *testing.T) {
 		rw = &mockMessageReadWriter{output: []msg{
 			{'q', 0, 0, 0, 5, 1},
 		}}
-		ok, err := a.authenticate(rw, args)
+		err := a.authenticate(rw, args)
 
-		require.False(t, ok)
 		require.Equal(t, passwordRequest, rw.messages[0])
 		require.True(t, bytes.Contains(rw.messages[1], fatalMarker))
 		require.NoError(t, err)
@@ -110,9 +106,8 @@ func TestAuthenticationMD5_authenticate(t *testing.T) {
 
 	t.Run("valid password", func(t *testing.T) {
 		defer rw.Reset()
-		ok, err := a.authenticate(rw, args)
+		err := a.authenticate(rw, args)
 
-		require.True(t, ok)
 		require.NoError(t, err)
 		require.True(t, bytes.Contains(rw.messages[0], passwordRequest))
 		require.Equal(t, authOKMessage, rw.messages[1])
@@ -121,9 +116,8 @@ func TestAuthenticationMD5_authenticate(t *testing.T) {
 	t.Run("invalid password", func(t *testing.T) {
 		defer rw.Read()
 		pp.password = []byte("shtoot")
-		ok, err := a.authenticate(rw, args)
+		err := a.authenticate(rw, args)
 
-		require.False(t, ok)
 		require.True(t, bytes.Contains(rw.messages[0], passwordRequest))
 		require.True(t, bytes.Contains(rw.messages[1], fatalMarker))
 		require.NoError(t, err)
@@ -134,9 +128,8 @@ func TestAuthenticationMD5_authenticate(t *testing.T) {
 		rw := &mockMessageReadWriter{output: []msg{
 			{'q', 0, 0, 0, 5, 1},
 		}}
-		ok, err := a.authenticate(rw, args)
+		err := a.authenticate(rw, args)
 
-		require.False(t, ok)
 		require.True(t, bytes.Contains(rw.messages[0], passwordRequest))
 		require.True(t, bytes.Contains(rw.messages[1], fatalMarker))
 		require.NoError(t, err)

--- a/auth_test.go
+++ b/auth_test.go
@@ -70,7 +70,7 @@ func TestAuthenticationClearText_authenticate(t *testing.T) {
 
 		require.Equal(t, passwordRequest, rw.messages[0])
 		require.True(t, bytes.Contains(rw.messages[1], fatalMarker))
-		require.NoError(t, err)
+		require.EqualError(t, err, "Password does not match for user \"this-is-user\"")
 	})
 
 	t.Run("invalid message type", func(t *testing.T) {
@@ -82,7 +82,7 @@ func TestAuthenticationClearText_authenticate(t *testing.T) {
 
 		require.Equal(t, passwordRequest, rw.messages[0])
 		require.True(t, bytes.Contains(rw.messages[1], fatalMarker))
-		require.NoError(t, err)
+		require.EqualError(t, err, "expected password response, got message type q")
 	})
 }
 
@@ -120,7 +120,7 @@ func TestAuthenticationMD5_authenticate(t *testing.T) {
 
 		require.True(t, bytes.Contains(rw.messages[0], passwordRequest))
 		require.True(t, bytes.Contains(rw.messages[1], fatalMarker))
-		require.NoError(t, err)
+		require.EqualError(t, err, "Password does not match for user \"postgres\"")
 	})
 
 	t.Run("invalid message type", func(t *testing.T) {
@@ -132,7 +132,7 @@ func TestAuthenticationMD5_authenticate(t *testing.T) {
 
 		require.True(t, bytes.Contains(rw.messages[0], passwordRequest))
 		require.True(t, bytes.Contains(rw.messages[1], fatalMarker))
-		require.NoError(t, err)
+		require.EqualError(t, err, "expected password response, got message type q")
 	})
 }
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,13 @@
+package pgsrv
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNoPassword_authenticate(t *testing.T) {
+	np := &noPassword{}
+	actualResult := np.authenticate()
+	expectedResult := msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+	require.Equal(t, actualResult, expectedResult)
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -7,6 +7,13 @@ import (
 
 var authOKMessage = msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}
 
+func TestAuthOKMsg(t *testing.T) {
+	actualResult := authOKMsg()
+	expectedResult := authOKMessage
+
+	require.Equal(t, expectedResult, actualResult)
+}
+
 func TestNoPassword_authenticate(t *testing.T) {
 	np := &authenticationNoPassword{}
 	actualResult, err := np.authenticate()

--- a/auth_test.go
+++ b/auth_test.go
@@ -16,7 +16,7 @@ func TestAuthOKMsg(t *testing.T) {
 }
 
 func TestNoPassword_authenticate(t *testing.T) {
-	np := &authenticationNoPassword{}
+	np := &noPasswordAuthenticator{}
 	actualResult, err := np.authenticate()
 	expectedResult := authOKMessage
 
@@ -36,7 +36,7 @@ func TestAuthenticationClearText_authenticate(t *testing.T) {
 	}
 	pp := &constantPasswordProvider{password: []byte("meh")}
 
-	a := &authenticationClearText{rw, args, pp}
+	a := &clearTextAuthenticator{rw, args, pp}
 
 	t.Run("valid password", func(t *testing.T) {
 		expectedResult := authOKMessage
@@ -76,7 +76,7 @@ func TestAuthenticationMD5_authenticate(t *testing.T) {
 	}
 	pp := &md5ConstantPasswordProvider{password: []byte("test")}
 
-	a := &authenticationMD5{rw, args, pp}
+	a := &md5Authenticator{rw, args, pp}
 
 	t.Run("valid password", func(t *testing.T) {
 		expectedResult := authOKMessage

--- a/auth_test.go
+++ b/auth_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 )
 
+var authOKMessage = msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+
 func TestNoPassword_authenticate(t *testing.T) {
 	np := &authenticationNoPassword{}
 	actualResult, err := np.authenticate()
-	expectedResult := msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+	expectedResult := authOKMessage
 
 	require.NoError(t, err)
 	require.Equal(t, actualResult, expectedResult)
@@ -29,7 +31,7 @@ func TestAuthenticationClearText_authenticate(t *testing.T) {
 	a := &authenticationClearText{rw, args, pp}
 
 	t.Run("valid password", func(t *testing.T) {
-		expectedResult := authOKMsg()
+		expectedResult := authOKMessage
 		actualResult, err := a.authenticate()
 
 		require.NoError(t, err)
@@ -69,7 +71,7 @@ func TestAuthenticationMD5_authenticate(t *testing.T) {
 	a := &authenticationMD5{rw, args, pp}
 
 	t.Run("valid password", func(t *testing.T) {
-		expectedResult := authOKMsg()
+		expectedResult := authOKMessage
 		actualResult, err := a.authenticate()
 
 		require.NoError(t, err)

--- a/auth_test.go
+++ b/auth_test.go
@@ -6,8 +6,181 @@ import (
 )
 
 func TestNoPassword_authenticate(t *testing.T) {
-	np := &noPassword{}
-	actualResult := np.authenticate()
+	np := &authenticationNoPassword{}
+	actualResult, err := np.authenticate()
 	expectedResult := msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}
+
+	require.NoError(t, err)
 	require.Equal(t, actualResult, expectedResult)
+}
+
+func TestAuthenticationClearText_authenticate(t *testing.T) {
+	passwordMessage := msg{
+		'p',
+		0, 0, 0, 8,
+		109, 101, 104, 0, // 'meh'
+	}
+	rw := &mockMessageReadWriter{output: []msg{passwordMessage}}
+	args := map[string]interface{}{
+		"user": "this-is-user",
+	}
+	pp := &constantPasswordProvider{password: []byte("meh")}
+
+	a := &authenticationClearText{rw, args, pp}
+
+	t.Run("valid password", func(t *testing.T) {
+		expectedResult := authOKMsg()
+		actualResult, err := a.authenticate()
+
+		require.NoError(t, err)
+		require.Equal(t, expectedResult, actualResult)
+	})
+
+	t.Run("invalid password", func(t *testing.T) {
+		pp.password = []byte("shtoot")
+		_, err := a.authenticate()
+
+		require.EqualError(t, err,
+			"Password does not match for user \"this-is-user\"")
+	})
+
+	t.Run("invalid message type", func(t *testing.T) {
+		a.rw = &mockMessageReadWriter{output: []msg{
+			{'q', 0, 0, 0, 5, 1},
+		}}
+		_, err := a.authenticate()
+
+		require.EqualError(t, err,
+			"expected password response, got message type q")
+	})
+}
+
+func TestAuthenticationMD5_authenticate(t *testing.T) {
+	rw := &mockMD5MessageReadWriter{
+		user: "postgres",
+		pass: []byte("test"),
+		salt: []byte{},
+	}
+	args := map[string]interface{}{
+		"user": "postgres",
+	}
+	pp := &constantPasswordProvider{password: []byte("test")}
+
+	a := &authenticationMD5{rw, args, pp}
+
+	t.Run("valid password", func(t *testing.T) {
+		expectedResult := authOKMsg()
+		actualResult, err := a.authenticate()
+
+		require.NoError(t, err)
+		require.Equal(t, expectedResult, actualResult)
+	})
+
+	t.Run("invalid password", func(t *testing.T) {
+		pp.password = []byte("shtoot")
+		_, err := a.authenticate()
+
+		require.EqualError(t, err,
+			"Password does not match for user \"postgres\"")
+	})
+
+	t.Run("invalid message type", func(t *testing.T) {
+		a.rw = &mockMessageReadWriter{output: []msg{
+			{'q', 0, 0, 0, 5, 1},
+		}}
+		_, err := a.authenticate()
+
+		require.EqualError(t, err,
+			"expected password response, got message type q")
+	})
+}
+
+func TestHashUserPassword(t *testing.T) {
+	user := "postgres"
+	pass := []byte("test")
+	salt := []byte{196, 53, 49, 235}
+
+	// actual hash received from psql using the above variables
+	expectedHash := []byte{
+		109, 100, 53, 97, 97, 51, 102, 56, 98, 56,
+		55, 97, 57, 51, 52, 97, 52, 53, 48, 52,
+		52, 101, 49, 102, 98, 50, 100, 57, 48, 55,
+		48, 99, 98, 56, 48,
+	}
+
+	actualHash := hashUserPassword(user, pass, salt)
+	require.Equal(t, expectedHash, actualHash)
+}
+
+func TestGetRandomSalt(t *testing.T) {
+	var lastSalt []byte
+	for i := 0; i < 100; i++ {
+		salt := getRandomSalt()
+		require.Equal(t, len(salt), 4)
+		require.NotEqual(t, lastSalt, salt)
+		lastSalt = salt
+	}
+}
+
+func TestExtractPassword(t *testing.T) {
+	t.Run("regular password", func(t *testing.T) {
+		passwordMessage := msg{
+			'p',
+			0, 0, 0, 9,
+			42, 42, 42, 42,
+			0,
+		}
+
+		expectedResult := []byte{42, 42, 42, 42}
+		actualResult := extractPassword(passwordMessage)
+		require.Equal(t, expectedResult, actualResult)
+	})
+
+	t.Run("empty password", func(t *testing.T) {
+		passwordMessage := msg{
+			'p',
+			0, 0, 0, 5,
+			0,
+		}
+
+		expectedResult := []byte{}
+		actualResult := extractPassword(passwordMessage)
+		require.Equal(t, expectedResult, actualResult)
+	})
+}
+
+// mockMessageReadWriter implements messageReadWriter and outputs the provided output
+// message by message, looped.
+type mockMessageReadWriter struct {
+	output        []msg
+	currentOutput int
+}
+
+func (rw *mockMessageReadWriter) Read() (msg, error) {
+	return rw.output[rw.currentOutput%len(rw.output)], nil
+}
+
+func (rw *mockMessageReadWriter) Write(m msg) error { return nil }
+
+// mockMD5MessageReadWriter implements messageReadWriter and outputs password
+// hashed with the salt received in Write() method
+type mockMD5MessageReadWriter struct {
+	user string
+	pass []byte
+	salt []byte
+}
+
+func (rw *mockMD5MessageReadWriter) Read() (msg, error) {
+	message := msg{
+		'p',
+		0, 0, 0, 25,
+	}
+	message = append(message, hashUserPassword(rw.user, rw.pass, rw.salt)...)
+	message = append(message, 0)
+	return message, nil
+}
+
+func (rw *mockMD5MessageReadWriter) Write(m msg) error {
+	rw.salt = m[9:len(m)]
+	return nil
 }

--- a/errors.go
+++ b/errors.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 )
 
-// FATAL error terminates session
-const FATAL = "FATAL"
+// fatalSeverity error terminates session
+const fatalSeverity = "FATAL"
 
 // Err is a postgres-compatible error object. It's not required to be used, as
 // any other normal error object would be converted to a generic internal error,

--- a/errors.go
+++ b/errors.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 )
 
+// FATAL error terminates session
+const FATAL = "FATAL"
+
 // Err is a postgres-compatible error object. It's not required to be used, as
 // any other normal error object would be converted to a generic internal error,
 // but it provides the API to generate user-friendly error messages. Note that

--- a/errors.go
+++ b/errors.go
@@ -26,6 +26,7 @@ import (
 type Err error
 
 type err struct {
+	S string // Severity
 	C string // Code
 	M string // Message
 	D string // Detail
@@ -33,11 +34,23 @@ type err struct {
 	P int    // Position
 }
 
-func (e *err) Code() string   { return e.C }
-func (e *err) Error() string  { return e.M }
-func (e *err) Detail() string { return e.D }
-func (e *err) Hint() string   { return e.H }
-func (e *err) Position() int  { return e.P }
+func (e *err) Severity() string { return e.S }
+func (e *err) Code() string     { return e.C }
+func (e *err) Error() string    { return e.M }
+func (e *err) Detail() string   { return e.D }
+func (e *err) Hint() string     { return e.H }
+func (e *err) Position() int    { return e.P }
+
+// WithSeverity decorates an error object to also include an optional severity
+func WithSeverity(err error, severity string) Err {
+	if err == nil {
+		return nil
+	}
+
+	e := fromErr(err)
+	e.S = severity
+	return e
+}
 
 // WithDetail decorates an error object to also include  an optional secondary
 // error message carrying more detail about the problem. Might run to multiple

--- a/errors.go
+++ b/errors.go
@@ -137,6 +137,14 @@ func fromErr(e error) *err {
 		return err1
 	}
 
+	severitier, ok := e.(interface {
+		Severity() string
+	})
+	s := ""
+	if ok {
+		s = severitier.Severity()
+	}
+
 	coder, ok := e.(interface {
 		Code() string
 	})
@@ -171,5 +179,5 @@ func fromErr(e error) *err {
 		p = positioner.Position()
 	}
 
-	return &err{C: c, M: m, D: d, H: h, P: p}
+	return &err{S: s, C: c, M: m, D: d, H: h, P: p}
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,38 @@
+package pgsrv
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestFromErr(t *testing.T) {
+	t.Run("already *err", func(t *testing.T) {
+		err := fmt.Errorf("this is an error")
+		expectedErr := fromErr(err)
+
+		actualErr := fromErr(expectedErr)
+		require.Equal(t, expectedErr, actualErr)
+	})
+
+	t.Run("all interfaces", func(t *testing.T) {
+		e := &mockErr{}
+		actualErr := fromErr(e)
+
+		require.Equal(t, "BAD", actualErr.Severity())
+		require.Equal(t, "13", actualErr.Code())
+		require.Equal(t, "This is bad", actualErr.Error())
+		require.Equal(t, "Some detail", actualErr.Detail())
+		require.Equal(t, "A hint", actualErr.Hint())
+		require.Equal(t, 42, actualErr.Position())
+	})
+}
+
+type mockErr struct{}
+
+func (*mockErr) Severity() string { return "BAD" }
+func (*mockErr) Code() string     { return "13" }
+func (*mockErr) Error() string    { return "This is bad" }
+func (*mockErr) Detail() string   { return "Some detail" }
+func (*mockErr) Hint() string     { return "A hint" }
+func (*mockErr) Position() int    { return 42 }

--- a/msg_query.go
+++ b/msg_query.go
@@ -106,6 +106,14 @@ func errMsg(err error) msg {
 		"M": err.Error(),
 	}
 
+	// severity
+	errSeverity, ok := err.(interface {
+		Severity() string
+	})
+	if ok && errSeverity.Severity() != "" {
+		fields["S"] = errSeverity.Severity()
+	}
+
 	// error code
 	errCode, ok := err.(interface {
 		Code() string

--- a/msg_startup.go
+++ b/msg_startup.go
@@ -82,12 +82,6 @@ func tlsResponseMsg(supported bool) msg {
 	return msg([]byte{b})
 }
 
-// NewAuthOK creates a new message indicating that the authentication was
-// successful
-func authOKMsg() msg {
-	return []byte{'R', 0, 0, 0, 8, 0, 0, 0, 0}
-}
-
 // KeyDataMsg creates a new message providing the client with a process ID and
 // secret key that it can later use to cancel running queries
 func keyDataMsg(pid int32, secret int32) msg {

--- a/sess.go
+++ b/sess.go
@@ -92,6 +92,8 @@ func (s *session) Serve() error {
 		return err
 	}
 
+	s.initialized = true
+
 	// handle authentication.
 	err = s.Write(authOKMsg())
 	if err != nil {
@@ -118,7 +120,6 @@ func (s *session) Serve() error {
 	}
 
 	// query-cycle
-	s.initialized = true
 	for {
 		// notify the client that we're ready for more messages.
 		err = s.Write(readyMsg())

--- a/sess.go
+++ b/sess.go
@@ -95,9 +95,7 @@ func (s *session) Serve() error {
 	s.initialized = true
 
 	// handle authentication.
-	// TODO: replace with an actual pre-configured authenticator
-	a := &noPasswordAuthenticator{}
-	ok, err := a.authenticate(s, s.Args)
+	ok, err := s.Server.authenticate(s, s.Args)
 	if err != nil {
 		return err
 	}

--- a/sess.go
+++ b/sess.go
@@ -95,7 +95,13 @@ func (s *session) Serve() error {
 	s.initialized = true
 
 	// handle authentication.
-	err = s.Write(authOKMsg())
+	a := &authenticationNoPassword{}
+	authResponse, err := a.authenticate()
+	if err != nil {
+		return s.Write(errMsg(WithSeverity(err, "FATAL")))
+	}
+
+	err = s.Write(authResponse)
 	if err != nil {
 		return err
 	}

--- a/sess.go
+++ b/sess.go
@@ -95,6 +95,7 @@ func (s *session) Serve() error {
 	s.initialized = true
 
 	// handle authentication.
+	// TODO: replace with an actual pre-configured authenticator
 	a := &authenticationNoPassword{}
 	authResponse, err := a.authenticate()
 	if err != nil {

--- a/sess.go
+++ b/sess.go
@@ -96,7 +96,7 @@ func (s *session) Serve() error {
 
 	// handle authentication.
 	// TODO: replace with an actual pre-configured authenticator
-	a := &authenticationNoPassword{}
+	a := &noPasswordAuthenticator{}
 	authResponse, err := a.authenticate()
 	if err != nil {
 		return s.Write(errMsg(WithSeverity(err, "FATAL")))

--- a/sess.go
+++ b/sess.go
@@ -97,14 +97,13 @@ func (s *session) Serve() error {
 	// handle authentication.
 	// TODO: replace with an actual pre-configured authenticator
 	a := &noPasswordAuthenticator{}
-	authResponse, err := a.authenticate()
-	if err != nil {
-		return s.Write(errMsg(WithSeverity(err, "FATAL")))
-	}
-
-	err = s.Write(authResponse)
+	ok, err := a.authenticate(s, s.Args)
 	if err != nil {
 		return err
+	}
+
+	if !ok {
+		return fmt.Errorf("authentication failed")
 	}
 
 	// generate cancellation pid and secret for this session

--- a/sess.go
+++ b/sess.go
@@ -95,13 +95,9 @@ func (s *session) Serve() error {
 	s.initialized = true
 
 	// handle authentication.
-	ok, err := s.Server.authenticate(s, s.Args)
+	err = s.Server.authenticate(s, s.Args)
 	if err != nil {
 		return err
-	}
-
-	if !ok {
-		return fmt.Errorf("authentication failed")
 	}
 
 	// generate cancellation pid and secret for this session

--- a/srv.go
+++ b/srv.go
@@ -18,6 +18,7 @@ type server struct {
 // also implements Execer, the returned server will also be able to handle
 // executing SQL commands (see Execer).
 func New(queryer Queryer) Server {
+	// TODO replace with an actual pre-configured authenticator
 	return &server{queryer, &noPasswordAuthenticator{}}
 }
 

--- a/srv.go
+++ b/srv.go
@@ -9,7 +9,8 @@ import (
 
 // implements the Server interface
 type server struct {
-	queryer Queryer
+	queryer       Queryer
+	authenticator authenticator
 }
 
 // New creates a Server object capable of handling postgres client connections.
@@ -17,7 +18,7 @@ type server struct {
 // also implements Execer, the returned server will also be able to handle
 // executing SQL commands (see Execer).
 func New(queryer Queryer) Server {
-	return &server{queryer}
+	return &server{queryer, &noPasswordAuthenticator{}}
 }
 
 // implements Queryer
@@ -60,4 +61,8 @@ func (s *server) Serve(conn net.Conn) error {
 		// TODO: Log it?
 	}
 	return err
+}
+
+func (s *server) authenticate(sess *session, args map[string]interface{}) (bool, error) {
+	return s.authenticator.authenticate(sess, args)
 }

--- a/srv.go
+++ b/srv.go
@@ -63,6 +63,6 @@ func (s *server) Serve(conn net.Conn) error {
 	return err
 }
 
-func (s *server) authenticate(sess *session, args map[string]interface{}) (bool, error) {
+func (s *server) authenticate(sess *session, args map[string]interface{}) error {
 	return s.authenticator.authenticate(sess, args)
 }


### PR DESCRIPTION
[Task](https://app.asana.com/0/573768021211412/768621478822192/f)

This PR adds `authenticator` interface and its 3 implementations:
- without password (to keep things as they are now)
- clear text password
- md5 hashed password

Last two implementations use dependency injection and delegate tasks like "get password for user" to provided objects. This also helps in testing (`auth.go` is almost completely covered with unit tests).

This PR also modifies `err` type: it adds a new field for severity (auth errors are `FATAL`; `ERROR` is not enough for them)

Currently, `sess.go` uses `authenticationNoPassword`. An example of md5 looks like the following:

```go
// password provider - implement when available
pp := &md5ConstantPasswordProvider{password: []byte("password")}

// authenticator that accepts current session as rw (readWriter),
// session args and password provider
a := &authenticationMD5{rw: s, args: s.Args, pp: pp}

authResponse, err := a.authenticate()
if err != nil {
	return s.Write(errMsg(WithSeverity(err, "FATAL")))
}
```