### PR TITLE
msg struct unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
 
 install:
   - go get -u github.com/golang/lint/golint
-  - go get github.com/lfittl/pg_query_go
+  - go get -t -v ./...
   - export PATH=$PATH:$HOME/.local/bin
 
 script:

--- a/msg_startup.go
+++ b/msg_startup.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-// Version returns the protocol version supported by the client. The version is
+// StartupVersion returns the protocol version supported by the client. The version is
 // encoded by two consequtive 2-byte integers, one for the major version, and
 // the other for the minor version. Currently version 3.0 is the only valid
 // version.
@@ -74,7 +74,7 @@ func (m msg) IsTerminate() bool {
 	return m.Type() == 'X'
 }
 
-// NewTLSResponse creates a new single byte message indicating if the server
+// tlsResponseMsg creates a new single byte message indicating if the server
 // supports TLS or not. If it does, the client must immediately proceed to
 // initiate the TLS handshake
 func tlsResponseMsg(supported bool) msg {
@@ -82,7 +82,7 @@ func tlsResponseMsg(supported bool) msg {
 	return msg([]byte{b})
 }
 
-// NewAuthOK creates a new message indicating that the authentication was
+// authOKMsg creates a new message indicating that the authentication was
 // successful
 func authOKMsg() msg {
 	return []byte{'R', 0, 0, 0, 8, 0, 0, 0, 0}

--- a/msg_startup_test.go
+++ b/msg_startup_test.go
@@ -109,3 +109,17 @@ func TestIsTerminate(t *testing.T) {
 		require.False(t, isTLS)
 	})
 }
+
+func TestTlsResponseMsg(t *testing.T) {
+	t.Run("supported", func(t *testing.T) {
+		m := tlsResponseMsg(true)
+
+		require.Equal(t, msg{'S'}, m)
+	})
+
+	t.Run("not supported", func(t *testing.T) {
+		m := tlsResponseMsg(false)
+
+		require.Equal(t, msg{'N'}, m)
+	})
+}

--- a/msg_startup_test.go
+++ b/msg_startup_test.go
@@ -129,3 +129,10 @@ func TestAuthOKMsg(t *testing.T) {
 
 	require.Equal(t, msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}, m)
 }
+
+func TestKeyDataMsg(t *testing.T) {
+	m := keyDataMsg(1325119140, 942490198)
+	expectedMessage := msg{75, 0, 0, 0, 12, 78, 251, 182, 164, 56, 45, 66, 86}
+
+	require.Equal(t, expectedMessage, m)
+}

--- a/msg_startup_test.go
+++ b/msg_startup_test.go
@@ -73,3 +73,21 @@ func TestStartupArgs(t *testing.T) {
 		require.Equal(t, expectedArgs, args)
 	})
 }
+
+func TestIsTLSRequest(t *testing.T) {
+	t.Run("tls", func(t *testing.T) {
+		// an actual message with version 1234.5679
+		m := &msg{0, 0, 0, 8, 4, 210, 22, 47}
+
+		isTLS := m.IsTLSRequest()
+		require.True(t, isTLS)
+	})
+
+	t.Run("not tls", func(t *testing.T) {
+		// an actual message with version 1234.5679 with modified last byte
+		m := &msg{0, 0, 0, 8, 4, 210, 22, 42}
+
+		isTLS := m.IsTLSRequest()
+		require.False(t, isTLS)
+	})
+}

--- a/msg_startup_test.go
+++ b/msg_startup_test.go
@@ -123,3 +123,9 @@ func TestTlsResponseMsg(t *testing.T) {
 		require.Equal(t, msg{'N'}, m)
 	})
 }
+
+func TestAuthOKMsg(t *testing.T) {
+	m := authOKMsg()
+
+	require.Equal(t, msg{'R', 0, 0, 0, 8, 0, 0, 0, 0}, m)
+}

--- a/msg_startup_test.go
+++ b/msg_startup_test.go
@@ -94,19 +94,17 @@ func TestIsTLSRequest(t *testing.T) {
 
 func TestIsTerminate(t *testing.T) {
 	t.Run("terminate", func(t *testing.T) {
-		// an actual message with version 1234.5679
 		m := &msg{'X', 0, 0, 0, 5}
 
-		isTLS := m.IsTerminate()
-		require.True(t, isTLS)
+		isTerminate := m.IsTerminate()
+		require.True(t, isTerminate)
 	})
 
-	t.Run("not tls", func(t *testing.T) {
-		// an actual message with version 1234.5679 with modified last byte
+	t.Run("not terminate", func(t *testing.T) {
 		m := &msg{'x', 0, 0, 0, 5}
 
-		isTLS := m.IsTerminate()
-		require.False(t, isTLS)
+		isTerminate := m.IsTerminate()
+		require.False(t, isTerminate)
 	})
 }
 
@@ -135,4 +133,22 @@ func TestKeyDataMsg(t *testing.T) {
 	expectedMessage := msg{75, 0, 0, 0, 12, 78, 251, 182, 164, 56, 45, 66, 86}
 
 	require.Equal(t, expectedMessage, m)
+}
+
+func TestIsCancel(t *testing.T) {
+	t.Run("cancel", func(t *testing.T) {
+		// an actual message with version 1234.5678
+		m := &msg{0, 0, 0, 8, 4, 210, 22, 46}
+
+		isCancel := m.IsCancel()
+		require.True(t, isCancel)
+	})
+
+	t.Run("not cancel", func(t *testing.T) {
+		// an actual message with version 1234.5678 with modified last byte
+		m := &msg{0, 0, 0, 8, 4, 210, 22, 42}
+
+		isCancel := m.IsCancel()
+		require.False(t, isCancel)
+	})
 }

--- a/msg_startup_test.go
+++ b/msg_startup_test.go
@@ -1,0 +1,26 @@
+package pgsrv
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestStartupVersion(t *testing.T) {
+	t.Run("typed message", func(t *testing.T) {
+		m := &msg{'p', 0, 0, 0, 5}
+		_, err := m.StartupVersion()
+
+		require.Error(t, err)
+	})
+
+	t.Run("untyped message", func(t *testing.T) {
+		m := &msg{
+			0, 0, 0, 8,
+			4, 210, 22, 47,
+		}
+		version, err := m.StartupVersion()
+
+		require.NoError(t, err)
+		require.Equal(t, "1234.5679", version)
+	})
+}

--- a/msg_startup_test.go
+++ b/msg_startup_test.go
@@ -24,3 +24,52 @@ func TestStartupVersion(t *testing.T) {
 		require.Equal(t, "1234.5679", version)
 	})
 }
+
+func TestStartupArgs(t *testing.T) {
+	t.Run("typed message", func(t *testing.T) {
+		m := &msg{'p', 0, 0, 0, 5}
+		_, err := m.StartupArgs()
+
+		require.Error(t, err)
+	})
+
+	t.Run("untyped message", func(t *testing.T) {
+		// an original message sent by psql client
+		m := &msg{
+			0, 0, 0, 84, 0, 3, 0, 0, 117, 115,
+			101, 114, 0, 112, 111, 115, 116, 103, 114, 101,
+			115, 0, 100, 97, 116, 97, 98, 97, 115, 101,
+			0, 112, 111, 115, 116, 103, 114, 101, 115, 0,
+			97, 112, 112, 108, 105, 99, 97, 116, 105, 111,
+			110, 95, 110, 97, 109, 101, 0, 112, 115, 113,
+			108, 0, 99, 108, 105, 101, 110, 116, 95, 101,
+			110, 99, 111, 100, 105, 110, 103, 0, 85, 84,
+			70, 56, 0, 0,
+		}
+
+		args, err := m.StartupArgs()
+		expectedArgs := map[string]interface{}{
+			"user":             "postgres",
+			"database":         "postgres",
+			"application_name": "psql",
+			"client_encoding":  "UTF8",
+		}
+
+		require.NoError(t, err)
+		require.Equal(t, expectedArgs, args)
+	})
+
+	t.Run("untyped message, no params", func(t *testing.T) {
+		m := &msg{
+			0, 0, 0, 9,
+			1, 2, 3, 4,
+			5, // this is an extra byte without a null terminator
+		}
+
+		args, err := m.StartupArgs()
+		expectedArgs := make(map[string]interface{})
+
+		require.NoError(t, err)
+		require.Equal(t, expectedArgs, args)
+	})
+}

--- a/msg_startup_test.go
+++ b/msg_startup_test.go
@@ -11,7 +11,7 @@ func TestStartupVersion(t *testing.T) {
 		m := &msg{'p', 0, 0, 0, 5}
 		_, err := m.StartupVersion()
 
-		require.Error(t, err)
+		require.EqualError(t, err, "Not an untyped startup message: 'p'")
 	})
 
 	t.Run("untyped message", func(t *testing.T) {
@@ -31,7 +31,7 @@ func TestStartupArgs(t *testing.T) {
 		m := &msg{'p', 0, 0, 0, 5}
 		_, err := m.StartupArgs()
 
-		require.Error(t, err)
+		require.EqualError(t, err, "Not an untyped startup message: 'p'")
 	})
 
 	t.Run("untyped message", func(t *testing.T) {
@@ -159,7 +159,7 @@ func TestCancelKeyData(t *testing.T) {
 		m := &msg{1, 2, 3, 4, 5, 6, 7, 8}
 		_, _, err := m.CancelKeyData()
 
-		require.Error(t, err)
+		require.EqualError(t, err, "Not a cancel message")
 	})
 
 	t.Run("cancel message", func(t *testing.T) {

--- a/msg_startup_test.go
+++ b/msg_startup_test.go
@@ -91,3 +91,21 @@ func TestIsTLSRequest(t *testing.T) {
 		require.False(t, isTLS)
 	})
 }
+
+func TestIsTerminate(t *testing.T) {
+	t.Run("terminate", func(t *testing.T) {
+		// an actual message with version 1234.5679
+		m := &msg{'X', 0, 0, 0, 5}
+
+		isTLS := m.IsTerminate()
+		require.True(t, isTLS)
+	})
+
+	t.Run("not tls", func(t *testing.T) {
+		// an actual message with version 1234.5679 with modified last byte
+		m := &msg{'x', 0, 0, 0, 5}
+
+		isTLS := m.IsTerminate()
+		require.False(t, isTLS)
+	})
+}

--- a/msg_test.go
+++ b/msg_test.go
@@ -1,0 +1,32 @@
+package pgsrv
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNewMsg(t *testing.T) {
+	bs := []byte{'p', 0, 0, 0, 5}
+	actualMessage := newMsg(bs)
+	expectedMessage := msg{'p', 0, 0, 0, 5}
+
+	require.Equal(t, expectedMessage, actualMessage)
+}
+
+func TestType(t *testing.T) {
+	t.Run("empty message", func(t *testing.T) {
+		m := msg{}
+		mt := m.Type()
+		expectedType := byte(0)
+
+		require.Equal(t, expectedType, mt)
+	})
+
+	t.Run("regular message", func(t *testing.T) {
+		m := msg{'p', 0, 0, 0, 5}
+		mt := m.Type()
+		expectedType := byte('p')
+
+		require.Equal(t, expectedType, mt)
+	})
+}


### PR DESCRIPTION
[Task](https://app.asana.com/0/573768021211412/461174053740749/f)

This PR adds unit tests for `msg` struct. It raises coverage from 0 to 12.4 percent. It is a part of a bigger task of adding tests to pgsrv.