### PR TITLE
Add unit tests for error constructors

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -28,6 +28,33 @@ func TestFromErr(t *testing.T) {
 	})
 }
 
+func TestUnrecognized(t *testing.T) {
+	e := Unrecognized("thing %s", "meh").(*err)
+	require.Equal(t, "42000", e.Code())
+	require.Equal(t, -1, e.Position())
+	require.Equal(t, "unrecognized thing meh", e.Error())
+}
+
+func TestInvalid(t *testing.T) {
+	e := Invalid("thing %s", "meh").(*err)
+	require.Equal(t, "42000", e.Code())
+	require.Equal(t, -1, e.Position())
+	require.Equal(t, "invalid thing meh", e.Error())
+}
+
+func TestDisallowed(t *testing.T) {
+	e := Disallowed("thing %s", "meh").(*err)
+	require.Equal(t, "42000", e.Code())
+	require.Equal(t, -1, e.Position())
+	require.Equal(t, "disallowed thing meh", e.Error())
+}
+func TestUnsupported(t *testing.T) {
+	e := Unsupported("thing %s", "meh").(*err)
+	require.Equal(t, "0A000", e.Code())
+	require.Equal(t, -1, e.Position())
+	require.Equal(t, "unsupported thing meh", e.Error())
+}
+
 type mockErr struct{}
 
 func (*mockErr) Severity() string { return "BAD" }


### PR DESCRIPTION
This PR adds unit tests to some of the constructors we use to create new errors.

Constructors include:
Unrecognized
Invalid
Disallowed
Unsupported