### PR TITLE
Test ready msg

### DIFF
--- a/msg_query_test.go
+++ b/msg_query_test.go
@@ -1,0 +1,11 @@
+package pgsrv
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestReadyMsg(t *testing.T) {
+	msg := readyMsg()
+	require.Equal(t, []byte{'Z', 0, 0, 0, 5, 'I'}, []byte(msg))
+}

--- a/msg_query_test.go
+++ b/msg_query_test.go
@@ -9,3 +9,15 @@ func TestReadyMsg(t *testing.T) {
 	msg := readyMsg()
 	require.Equal(t, []byte{'Z', 0, 0, 0, 5, 'I'}, []byte(msg))
 }
+
+func TestCompleteMsg(t *testing.T) {
+	msg := completeMsg("meh")
+	expectedMsg := []byte{
+		'C',        // type
+		0, 0, 0, 8, // size
+		109, 101, 104, // meh in bytes
+		0, // null terminator
+	}
+
+	require.Equal(t, expectedMsg, []byte(msg))
+}


### PR DESCRIPTION
This PR adds a missing tests for 2 more functions:
`readyMsg` and `completeMsg`.