### PR TITLE
Use md5 when server implements passwordProvider

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -40,7 +40,7 @@ type msgReadWriter interface {
 
 // passwordProvider describes objects that are able to provide a password given a user name.
 type passwordProvider interface {
-	getPassword(user string) ([]byte, error)
+	GetPassword(user string) ([]byte, error)
 }
 
 // constantPasswordProvider is a password provider that always returns the same password,
@@ -49,7 +49,7 @@ type constantPasswordProvider struct {
 	password []byte
 }
 
-func (cpp *constantPasswordProvider) getPassword(user string) ([]byte, error) {
+func (cpp *constantPasswordProvider) GetPassword(user string) ([]byte, error) {
 	return cpp.password, nil
 }
 
@@ -59,7 +59,7 @@ type md5ConstantPasswordProvider struct {
 	password []byte
 }
 
-func (cpp *md5ConstantPasswordProvider) getPassword(user string) ([]byte, error) {
+func (cpp *md5ConstantPasswordProvider) GetPassword(user string) ([]byte, error) {
 	pu := append(cpp.password, []byte(user)...)
 	puHash := md5.Sum(pu)
 	return puHash[:], nil
@@ -99,7 +99,7 @@ func (a *clearTextAuthenticator) authenticate(rw msgReadWriter, args map[string]
 	}
 
 	user := args["user"].(string)
-	expectedPassword, err := a.pp.getPassword(user)
+	expectedPassword, err := a.pp.GetPassword(user)
 	actualPassword := extractPassword(m)
 
 	if !bytes.Equal(expectedPassword, actualPassword) {
@@ -147,7 +147,7 @@ func (a *md5Authenticator) authenticate(rw msgReadWriter, args map[string]interf
 	}
 
 	user := args["user"].(string)
-	storedHash, err := a.pp.getPassword(user)
+	storedHash, err := a.pp.GetPassword(user)
 	expectedHash := hashWithSalt(storedHash, salt)
 
 	actualHash := extractPassword(m)

--- a/srv.go
+++ b/srv.go
@@ -17,9 +17,17 @@ type server struct {
 // It delegates query execution to the provided Queryer. If the provided Queryer
 // also implements Execer, the returned server will also be able to handle
 // executing SQL commands (see Execer).
+//
+// If queryer implements passwordProvider interface, a new server will be protected
+// with a new md5Authenticator.
 func New(queryer Queryer) Server {
-	// TODO replace with an actual pre-configured authenticator
-	return &server{queryer, &noPasswordAuthenticator{}}
+	var auth authenticator
+	auth = &noPasswordAuthenticator{}
+	pp, ok := queryer.(passwordProvider)
+	if ok {
+		auth = &md5Authenticator{pp}
+	}
+	return &server{queryer, auth}
 }
 
 // implements Queryer


### PR DESCRIPTION
[Task](https://app.asana.com/0/573768021211412/776881912418420/f)

From this PR, when a server is created with a `queryer` that is also a `passwordProvider`, md5 authentication will be used.