### PR TITLE
Do not skip CREATE TABLE results

### DIFF
--- a/query.go
+++ b/query.go
@@ -167,7 +167,6 @@ func (res *tagger) Tag() (tag string, err error) {
 		skipResults = true
 		tag = "CREATE VIEW"
 	case nodes.CreateStmt:
-		skipResults = true
 		tag = "CREATE TABLE"
 	case nodes.UpdateStmt:
 		tag = "UPDATE"


### PR DESCRIPTION
[Task](https://app.asana.com/0/573768021211412/1107571694338463/f)

This PR adds affected rows count to CreateStmt return tag. It was previously skipped since it was not fully supported. Now I'm working on adding affected row count, and this flag is becoming unnecessary.