### PR TITLE
fixed a bug in startup phase

### DIFF
--- a/protocol/extend.go
+++ b/protocol/extend.go
@@ -27,7 +27,7 @@ type transaction struct {
 
 // Read uses Transport to read the next message into the transaction's incoming messages buffer
 func (t *transaction) Read() (msg Message, err error) {
-	if msg, err = t.transport.read(); err == nil {
+	if msg, err = t.transport.Read(); err == nil {
 		t.in = append(t.in, msg)
 	}
 	return

--- a/protocol/transport.go
+++ b/protocol/transport.go
@@ -25,7 +25,7 @@ type Transport struct {
 // StartUp handles the very first messages exchange between frontend and backend of new session
 func (t *Transport) StartUp() (Message, error) {
 	// read the initial connection startup message
-	msg, err := t.read()
+	msg, err := t.Read()
 	if err != nil {
 		return nil, err
 	}
@@ -71,22 +71,26 @@ func (t *Transport) endTransaction() (err error) {
 	return
 }
 
-// Read reads and returns a single message from the connection.
-// Read expects to be called only after a call to StartUp without an error response
+// WaitForMessage reads and returns a single message from the connection when available.
+// if within a transaction, the transaction will read from the connection,
+// otherwise a ReadyForQuery message will first be sent to the frontend and then reading
+// a single message from the connection will happen
+//
+// WaitForMessage expects to be called only after a call to StartUp without an error response
 // otherwise, an error is returned
-func (t *Transport) Read() (msg Message, err error) {
+func (t *Transport) WaitForMessage() (msg Message, err error) {
+	if !t.initialized {
+		err = fmt.Errorf("transport not yet initialized")
+		return
+	}
 	if t.transaction != nil {
 		msg, err = t.transaction.Read()
 	} else {
-		if !t.initialized {
-			err = fmt.Errorf("transport not yet initialized")
-			return
-		}
 		err = t.Write(ReadyForQuery)
 		if err != nil {
 			return
 		}
-		msg, err = t.read()
+		msg, err = t.Read()
 	}
 	if err != nil {
 		return
@@ -101,7 +105,8 @@ func (t *Transport) Read() (msg Message, err error) {
 	return
 }
 
-func (t *Transport) read() (Message, error) {
+// Read reads and returns a single message from the connection.
+func (t *Transport) Read() (Message, error) {
 	typeChar := make([]byte, 1)
 
 	if t.initialized {

--- a/protocol/transport.go
+++ b/protocol/transport.go
@@ -71,14 +71,14 @@ func (t *Transport) endTransaction() (err error) {
 	return
 }
 
-// WaitForMessage reads and returns a single message from the connection when available.
+// NextMessage reads and returns a single message from the connection when available.
 // if within a transaction, the transaction will read from the connection,
 // otherwise a ReadyForQuery message will first be sent to the frontend and then reading
 // a single message from the connection will happen
 //
-// WaitForMessage expects to be called only after a call to StartUp without an error response
+// NextMessage expects to be called only after a call to StartUp without an error response
 // otherwise, an error is returned
-func (t *Transport) WaitForMessage() (msg Message, err error) {
+func (t *Transport) NextMessage() (msg Message, err error) {
 	if !t.initialized {
 		err = fmt.Errorf("transport not yet initialized")
 		return
@@ -86,6 +86,7 @@ func (t *Transport) WaitForMessage() (msg Message, err error) {
 	if t.transaction != nil {
 		msg, err = t.transaction.Read()
 	} else {
+		// when not in transaction, client waits for ReadyForQuery before sending next message
 		err = t.Write(ReadyForQuery)
 		if err != nil {
 			return

--- a/protocol/transport_test.go
+++ b/protocol/transport_test.go
@@ -85,12 +85,12 @@ func TestProtocol_Read(t *testing.T) {
 		frontend, err := pgproto3.NewFrontend(f, f)
 		require.NoError(t, err)
 
-		p := NewTransport(b, b)
-		p.initialized = true
+		transport := NewTransport(b, b)
+		transport.initialized = true
 
 		msg := make(chan Message)
 		go func() {
-			m, err := p.Read()
+			m, err := transport.WaitForMessage()
 			require.NoError(t, err)
 
 			msg <- m
@@ -106,19 +106,19 @@ func TestProtocol_Read(t *testing.T) {
 		res := <-msg
 		require.Equalf(t, byte('Q'), res.Type(), "expected protocol to identify sent message as type 'Q'. actual: %c", res.Type())
 
-		require.Nil(t, p.transaction, "expected protocol not to start transaction")
+		require.Nil(t, transport.transaction, "expected protocol not to start transaction")
 	})
 
 	t.Run("extended query message flow", func(t *testing.T) {
 		t.Run("starts transaction", func(t *testing.T) {
 			f, b := net.Pipe()
 
-			p := NewTransport(b, b)
-			p.initialized = true
+			transport := NewTransport(b, b)
+			transport.initialized = true
 
 			go func() {
 				for {
-					_, err := p.Read()
+					_, err := transport.WaitForMessage()
 					require.NoError(t, err)
 				}
 			}()
@@ -130,25 +130,25 @@ func TestProtocol_Read(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.NotNil(t, p.transaction, "expected protocol to start transaction")
+			require.NotNil(t, transport.transaction, "expected protocol to start transaction")
 		})
 
 		t.Run("ends transaction", func(t *testing.T) {
 			f, b := net.Pipe()
 
-			p := NewTransport(b, b)
-			p.initialized = true
+			transport := NewTransport(b, b)
+			transport.initialized = true
 
 			go func() {
 				for {
-					m, err := p.Read()
+					m, err := transport.WaitForMessage()
 					require.NoError(t, err)
 
 					switch m.Type() {
 					case Parse:
-						err = p.Write(ParseComplete)
+						err = transport.Write(ParseComplete)
 					case Bind:
-						err = p.Write(BindComplete)
+						err = transport.Write(BindComplete)
 					}
 					require.NoError(t, err)
 				}
@@ -166,7 +166,7 @@ func TestProtocol_Read(t *testing.T) {
 
 			require.NoError(t, err)
 
-			require.Nil(t, p.transaction, "expected protocol to end transaction")
+			require.Nil(t, transport.transaction, "expected protocol to end transaction")
 		})
 	})
 }

--- a/protocol/transport_test.go
+++ b/protocol/transport_test.go
@@ -90,7 +90,7 @@ func TestProtocol_Read(t *testing.T) {
 
 		msg := make(chan Message)
 		go func() {
-			m, err := transport.WaitForMessage()
+			m, err := transport.NextMessage()
 			require.NoError(t, err)
 
 			msg <- m
@@ -118,7 +118,7 @@ func TestProtocol_Read(t *testing.T) {
 
 			go func() {
 				for {
-					_, err := transport.WaitForMessage()
+					_, err := transport.NextMessage()
 					require.NoError(t, err)
 				}
 			}()
@@ -141,7 +141,7 @@ func TestProtocol_Read(t *testing.T) {
 
 			go func() {
 				for {
-					m, err := transport.WaitForMessage()
+					m, err := transport.NextMessage()
 					require.NoError(t, err)
 
 					switch m.Type() {

--- a/sess.go
+++ b/sess.go
@@ -91,7 +91,7 @@ func (s *session) Serve() error {
 
 	// query-cycle
 	for {
-		msg, err = t.WaitForMessage()
+		msg, err = t.NextMessage()
 		if err != nil {
 			return err
 		}

--- a/sess.go
+++ b/sess.go
@@ -91,7 +91,7 @@ func (s *session) Serve() error {
 
 	// query-cycle
 	for {
-		msg, err = t.Read()
+		msg, err = t.WaitForMessage()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
transport exposed Read function which also sent ready-for-query message prior to reading. because transport is also being used for authentication, ready-for-query message has been sent in the authentication phase which is part of the startup